### PR TITLE
fix `compare` function's return type

### DIFF
--- a/lib/akin.ex
+++ b/lib/akin.ex
@@ -32,7 +32,7 @@ defmodule Akin do
   alias Akin.Corpus
   alias Akin.Names
 
-  @spec compare(binary() | %Corpus{}, binary() | %Corpus{}, keyword()) :: float()
+  @spec compare(binary() | %Corpus{}, binary() | %Corpus{}, keyword()) :: map()
   @doc """
   Compare two strings. Return map of algorithm metrics.
 


### PR DESCRIPTION
Hi!

`dialyzer` compares that the type of the `compare` function is not matching the expected one.
`compare` function should return a map, if I am getting things right.